### PR TITLE
HALSim Websocket Server Environment Variable Cleanup

### DIFF
--- a/simulation/samples/JavaAutoSample/build.gradle
+++ b/simulation/samples/JavaAutoSample/build.gradle
@@ -91,7 +91,6 @@ test {
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()
 
-wpi.sim.envVar("HALSIMWS_HOST", "127.0.0.1")
 wpi.sim.addWebsocketsServer().defaultEnabled = true
 
 // Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')

--- a/simulation/samples/JavaSample/build.gradle
+++ b/simulation/samples/JavaSample/build.gradle
@@ -91,7 +91,6 @@ test {
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()
 
-wpi.sim.envVar("HALSIMWS_HOST", "127.0.0.1")
 wpi.sim.addWebsocketsServer().defaultEnabled = true
 
 // Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')


### PR DESCRIPTION
### Description
Removes the use of the host environment variables from our sample WPILib projects.

See [original PR](https://github.com/Autodesk/synthesis/pull/1115).